### PR TITLE
Jumpstart - split 6 basic M21 lands into each basic 2,2,2 split

### DIFF
--- a/decklists/MTG-JMP-B-Discarding1.csv
+++ b/decklists/MTG-JMP-B-Discarding1.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Slate Street Ruffian,279,Jumpstart,English
 2,Wight of Precinct Six,287,Jumpstart,English
 1,Mind Rot,115,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Discarding2.csv
+++ b/decklists/MTG-JMP-B-Discarding2.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Ravenous Chupacabra,269,Jumpstart,English
 1,Slate Street Ruffian,279,Jumpstart,English
 2,Wight of Precinct Six,287,Jumpstart,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Liliana.csv
+++ b/decklists/MTG-JMP-B-Liliana.csv
@@ -13,5 +13,7 @@ Count,Name,Card Number,Edition,Language
 1,Liliana's Standard Bearer,110,Core Set 2021,English
 1,Liliana's Steward,111,Core Set 2021,English
 1,Rise Again,119,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English
 1,Swamp,311,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Minions1.csv
+++ b/decklists/MTG-JMP-B-Minions1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Goremand,101,Core Set 2021,English
 1,Village Rites,126,Core Set 2021,English
 1,Witch's Cauldron,129,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Minions2.csv
+++ b/decklists/MTG-JMP-B-Minions2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Goremand,101,Core Set 2021,English
 1,Village Rites,126,Core Set 2021,English
 1,Witch's Cauldron,129,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Minions4.csv
+++ b/decklists/MTG-JMP-B-Minions4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Liliana's Devotee,109,Core Set 2021,English
 1,Village Rites,126,Core Set 2021,English
 1,Witch's Cauldron,129,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Phyrexian.csv
+++ b/decklists/MTG-JMP-B-Phyrexian.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Myr Sire,475,Jumpstart,English
 1,Perilous Myr,476,Jumpstart,English
 1,Malefic Scythe,112,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Reanimated1.csv
+++ b/decklists/MTG-JMP-B-Reanimated1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Eliminate,97,Core Set 2021,English
 1,Goremand,101,Core Set 2021,English
 1,Rise Again,119,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Reanimated2.csv
+++ b/decklists/MTG-JMP-B-Reanimated2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Gloom Sower,100,Core Set 2021,English
 1,Goremand,101,Core Set 2021,English
 1,Rise Again,119,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Reanimated3.csv
+++ b/decklists/MTG-JMP-B-Reanimated3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Eliminate,97,Core Set 2021,English
 1,Goremand,101,Core Set 2021,English
 1,Rise Again,119,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Reanimated4.csv
+++ b/decklists/MTG-JMP-B-Reanimated4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Gloom Sower,100,Core Set 2021,English
 1,Goremand,101,Core Set 2021,English
 1,Rise Again,119,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Rogues1.csv
+++ b/decklists/MTG-JMP-B-Rogues1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Finishing Blow,99,Core Set 2021,English
 1,Masked Blackguard,113,Core Set 2021,English
 1,Thieves' Guild Enforcer,125,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Rogues2.csv
+++ b/decklists/MTG-JMP-B-Rogues2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Alchemist's Gift,87,Core Set 2021,English
 1,Masked Blackguard,113,Core Set 2021,English
 1,Thieves' Guild Enforcer,125,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Spooky1.csv
+++ b/decklists/MTG-JMP-B-Spooky1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Liliana's Standard Bearer,110,Core Set 2021,English
 1,Malefic Scythe,112,Core Set 2021,English
 1,Village Rites,126,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Spooky2.csv
+++ b/decklists/MTG-JMP-B-Spooky2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Crypt Lurker,93,Core Set 2021,English
 1,Finishing Blow,99,Core Set 2021,English
 1,Malefic Scythe,112,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Spooky3.csv
+++ b/decklists/MTG-JMP-B-Spooky3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Finishing Blow,99,Core Set 2021,English
 1,Liliana's Devotee,109,Core Set 2021,English
 1,Malefic Scythe,112,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Spooky4.csv
+++ b/decklists/MTG-JMP-B-Spooky4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Finishing Blow,99,Core Set 2021,English
 1,Liliana's Devotee,109,Core Set 2021,English
 1,Malefic Scythe,112,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Vampires1.csv
+++ b/decklists/MTG-JMP-B-Vampires1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Sanguine Indulgence,121,Core Set 2021,English
 1,Silversmote Ghoul,122,Core Set 2021,English
 1,"Vito, Thorn of the Dusk Rose",127,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Vampires2.csv
+++ b/decklists/MTG-JMP-B-Vampires2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Sanguine Indulgence,121,Core Set 2021,English
 1,Silversmote Ghoul,122,Core Set 2021,English
 1,"Vito, Thorn of the Dusk Rose",127,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Vampires3.csv
+++ b/decklists/MTG-JMP-B-Vampires3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Gloom Sower,100,Core Set 2021,English
 1,Sanguine Indulgence,121,Core Set 2021,English
 1,Silversmote Ghoul,122,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Vampires4.csv
+++ b/decklists/MTG-JMP-B-Vampires4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Gloom Sower,100,Core Set 2021,English
 1,Sanguine Indulgence,121,Core Set 2021,English
 1,Silversmote Ghoul,122,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Witchcraft1.csv
+++ b/decklists/MTG-JMP-B-Witchcraft1.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Bubbling Cauldron,460,Jumpstart,English
 1,Finishing Blow,99,Core Set 2021,English
 1,Witch's Cauldron,129,Core Set 2021,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-B-Witchcraft2.csv
+++ b/decklists/MTG-JMP-B-Witchcraft2.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Swarm of Bloodflies,282,Jumpstart,English
 1,Tempting Witch,283,Jumpstart,English
 1,Bubbling Cauldron,460,Jumpstart,English
-6,Swamp,,Core Set 2021,English
+2,Swamp,266,Core Set 2021,English
+2,Swamp,267,Core Set 2021,English
+2,Swamp,268,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Cats1.csv
+++ b/decklists/MTG-JMP-G-Cats1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Feline Sovereign,180,Core Set 2021,English
 1,Pridemalkin,196,Core Set 2021,English
 1,Sabertooth Mauler,202,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Cats2.csv
+++ b/decklists/MTG-JMP-G-Cats2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Canopy Stalker,175,Core Set 2021,English
 1,Feline Sovereign,180,Core Set 2021,English
 1,Pridemalkin,196,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Dinosaurs1.csv
+++ b/decklists/MTG-JMP-G-Dinosaurs1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Ornery Dilophosaur,194,Core Set 2021,English
 1,Setessan Training,205,Core Set 2021,English
 1,Thrashing Brontodon,209,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Dinosaurs2.csv
+++ b/decklists/MTG-JMP-G-Dinosaurs2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Drowsing Tyrannodon,178,Core Set 2021,English
 1,Ornery Dilophosaur,194,Core Set 2021,English
 1,Titanic Growth,210,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Dinosaurs3.csv
+++ b/decklists/MTG-JMP-G-Dinosaurs3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Drowsing Tyrannodon,178,Core Set 2021,English
 1,Garruk's Uprising,186,Core Set 2021,English
 1,Ornery Dilophosaur,194,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Dinosaurs4.csv
+++ b/decklists/MTG-JMP-G-Dinosaurs4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Ornery Dilophosaur,194,Core Set 2021,English
 1,Primal Might,197,Core Set 2021,English
 1,Thrashing Brontodon,209,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Elves1.csv
+++ b/decklists/MTG-JMP-G-Elves1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Llanowar Visionary,193,Core Set 2021,English
 1,Skyway Sniper,206,Core Set 2021,English
 1,Titanic Growth,210,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Elves2.csv
+++ b/decklists/MTG-JMP-G-Elves2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Llanowar Visionary,193,Core Set 2021,English
 1,Skyway Sniper,206,Core Set 2021,English
 1,Titanic Growth,210,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Garruk.csv
+++ b/decklists/MTG-JMP-G-Garruk.csv
@@ -13,5 +13,7 @@ Count,Name,Card Number,Edition,Language
 1,Garruk's Uprising,186,Core Set 2021,English
 1,Hunter's Edge,189,Core Set 2021,English
 1,Ranger's Guile,199,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English
 1,Forest,313,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Lands1.csv
+++ b/decklists/MTG-JMP-G-Lands1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Wildheart Invoker,444,Jumpstart,English
 1,Zendikar's Roil,448,Jumpstart,English
 1,Cultivate,177,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Lands2.csv
+++ b/decklists/MTG-JMP-G-Lands2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Wildheart Invoker,444,Jumpstart,English
 1,Woodborn Behemoth,446,Jumpstart,English
 1,Cultivate,177,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Predatory1.csv
+++ b/decklists/MTG-JMP-G-Predatory1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Fungal Rebirth,182,Core Set 2021,English
 1,Sabertooth Mauler,202,Core Set 2021,English
 1,Trufflesnout,212,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Predatory2.csv
+++ b/decklists/MTG-JMP-G-Predatory2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Fungal Rebirth,182,Core Set 2021,English
 1,Sabertooth Mauler,202,Core Set 2021,English
 1,Trufflesnout,212,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Predatory3.csv
+++ b/decklists/MTG-JMP-G-Predatory3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Fungal Rebirth,182,Core Set 2021,English
 1,Sabertooth Mauler,202,Core Set 2021,English
 1,Trufflesnout,212,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Predatory4.csv
+++ b/decklists/MTG-JMP-G-Predatory4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Fungal Rebirth,182,Core Set 2021,English
 1,Sabertooth Mauler,202,Core Set 2021,English
 1,Trufflesnout,212,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-TreeHugging1.csv
+++ b/decklists/MTG-JMP-G-TreeHugging1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Llanowar Visionary,193,Core Set 2021,English
 1,Snarespinner,207,Core Set 2021,English
 1,Warden of the Woods,213,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-TreeHugging2.csv
+++ b/decklists/MTG-JMP-G-TreeHugging2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Llanowar Visionary,193,Core Set 2021,English
 1,Snarespinner,207,Core Set 2021,English
 1,Warden of the Woods,213,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-TreeHugging3.csv
+++ b/decklists/MTG-JMP-G-TreeHugging3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Llanowar Visionary,193,Core Set 2021,English
 1,Snarespinner,207,Core Set 2021,English
 1,Warden of the Woods,213,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-TreeHugging4.csv
+++ b/decklists/MTG-JMP-G-TreeHugging4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Llanowar Visionary,193,Core Set 2021,English
 1,Snarespinner,207,Core Set 2021,English
 1,Warden of the Woods,213,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-G-Walls.csv
+++ b/decklists/MTG-JMP-G-Walls.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Roving Keep,480,Jumpstart,English
 1,Warmonger's Chariot,490,Jumpstart,English
 1,Portcullis Vine,195,Core Set 2021,English
-6,Forest,,Core Set 2021,English
+2,Forest,272,Core Set 2021,English
+2,Forest,273,Core Set 2021,English
+2,Forest,274,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Chandra.csv
+++ b/decklists/MTG-JMP-R-Chandra.csv
@@ -12,5 +12,7 @@ Count,Name,Card Number,Edition,Language
 2,Chandra's Magmutt,137,Core Set 2021,English
 1,Chandra's Pyreling,138,Core Set 2021,English
 1,Thrill of Possibility,165,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English
 1,Mountain,312,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Devilish1.csv
+++ b/decklists/MTG-JMP-R-Devilish1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Hobblefiend,152,Core Set 2021,English
 1,Pitchburn Devils,156,Core Set 2021,English
 1,Traitorous Greed,166,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Devilish2.csv
+++ b/decklists/MTG-JMP-R-Devilish2.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Hobblefiend,152,Core Set 2021,English
 1,Pitchburn Devils,156,Core Set 2021,English
 1,Traitorous Greed,166,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Devilish3.csv
+++ b/decklists/MTG-JMP-R-Devilish3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Hobblefiend,152,Core Set 2021,English
 1,Pitchburn Devils,156,Core Set 2021,English
 1,Traitorous Greed,166,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Devilish4.csv
+++ b/decklists/MTG-JMP-R-Devilish4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Hobblefiend,152,Core Set 2021,English
 1,Pitchburn Devils,156,Core Set 2021,English
 1,Traitorous Greed,166,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Goblins1.csv
+++ b/decklists/MTG-JMP-R-Goblins1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Volley Veteran,369,Jumpstart,English
 1,Goblin Arsonist,147,Core Set 2021,English
 1,Shock,159,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Goblins2.csv
+++ b/decklists/MTG-JMP-R-Goblins2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Battle-Rattle Shaman,130,Core Set 2021,English
 1,Burn Bright,134,Core Set 2021,English
 1,Goblin Arsonist,147,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Goblins3.csv
+++ b/decklists/MTG-JMP-R-Goblins3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Volley Veteran,369,Jumpstart,English
 1,Goblin Arsonist,147,Core Set 2021,English
 1,Shock,159,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Goblins4.csv
+++ b/decklists/MTG-JMP-R-Goblins4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Outnumber,354,Jumpstart,English
 1,Burn Bright,134,Core Set 2021,English
 1,Goblin Arsonist,147,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Lightning1.csv
+++ b/decklists/MTG-JMP-R-Lightning1.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Lightning Elemental,344,Jumpstart,English
 1,Lightning Shrieker,345,Jumpstart,English
 1,Weaver of Lightning,371,Jumpstart,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Lightning2.csv
+++ b/decklists/MTG-JMP-R-Lightning2.csv
@@ -13,4 +13,6 @@ Count,Name,Card Number,Edition,Language
 1,Lightning Elemental,344,Jumpstart,English
 1,Riddle of Lightning,359,Jumpstart,English
 1,Weaver of Lightning,371,Jumpstart,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Minotaurs1.csv
+++ b/decklists/MTG-JMP-R-Minotaurs1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Herald's Horn,469,Jumpstart,English
 1,Soul Sear,160,Core Set 2021,English
 1,Sure Strike,163,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Minotaurs2.csv
+++ b/decklists/MTG-JMP-R-Minotaurs2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Sure Strike,163,Core Set 2021,English
 1,Traitorous Greed,166,Core Set 2021,English
 1,Unleash Fury,170,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Seismic.csv
+++ b/decklists/MTG-JMP-R-Seismic.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Volcanic Fallout,368,Jumpstart,English
 1,Mana Geode,472,Jumpstart,English
 1,Volcanic Geyser,171,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Smashing1.csv
+++ b/decklists/MTG-JMP-R-Smashing1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Turret Ogre,169,Core Set 2021,English
 1,Unleash Fury,170,Core Set 2021,English
 1,Volcanic Salvo,172,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Smashing2.csv
+++ b/decklists/MTG-JMP-R-Smashing2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Turret Ogre,169,Core Set 2021,English
 1,Volcanic Salvo,172,Core Set 2021,English
 1,Short Sword,236,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Smashing3.csv
+++ b/decklists/MTG-JMP-R-Smashing3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Onakke Ogre,155,Core Set 2021,English
 1,Turret Ogre,169,Core Set 2021,English
 1,Unleash Fury,170,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Smashing4.csv
+++ b/decklists/MTG-JMP-R-Smashing4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Heartfire Immolator,150,Core Set 2021,English
 1,Onakke Ogre,155,Core Set 2021,English
 1,Turret Ogre,169,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Spellcasting1.csv
+++ b/decklists/MTG-JMP-R-Spellcasting1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Kinetic Augur,154,Core Set 2021,English
 1,Shock,159,Core Set 2021,English
 1,Thrill of Possibility,165,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Spellcasting2.csv
+++ b/decklists/MTG-JMP-R-Spellcasting2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Kinetic Augur,154,Core Set 2021,English
 1,Shock,159,Core Set 2021,English
 1,Thrill of Possibility,165,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Spellcasting3.csv
+++ b/decklists/MTG-JMP-R-Spellcasting3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Kinetic Augur,154,Core Set 2021,English
 1,Shock,159,Core Set 2021,English
 1,Thrill of Possibility,165,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-R-Spellcasting4.csv
+++ b/decklists/MTG-JMP-R-Spellcasting4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Kinetic Augur,154,Core Set 2021,English
 1,Shock,159,Core Set 2021,English
 1,Thrill of Possibility,165,Core Set 2021,English
-6,Mountain,,Core Set 2021,English
+2,Mountain,269,Core Set 2021,English
+2,Mountain,270,Core Set 2021,English
+2,Mountain,271,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Clouds1.csv
+++ b/decklists/MTG-JMP-U-Clouds1.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Tide Skimmer,79,Core Set 2021,English
 1,Unsubstantiate,82,Core Set 2021,English
 1,Wall of Runes,85,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Clouds1.csv
+++ b/decklists/MTG-JMP-U-Clouds1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Tide Skimmer,79,Core Set 2021,English
 1,Unsubstantiate,82,Core Set 2021,English
 1,Wall of Runes,85,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Clouds4.csv
+++ b/decklists/MTG-JMP-U-Clouds4.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Tide Skimmer,79,Core Set 2021,English
 1,Unsubstantiate,82,Core Set 2021,English
 1,Wall of Runes,85,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Clouds4.csv
+++ b/decklists/MTG-JMP-U-Clouds4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Tide Skimmer,79,Core Set 2021,English
 1,Unsubstantiate,82,Core Set 2021,English
 1,Wall of Runes,85,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Milling.csv
+++ b/decklists/MTG-JMP-U-Milling.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Wall of Lost Thoughts,190,Jumpstart,English
 1,Capture Sphere,47,Core Set 2021,English
 1,Teferi's Tutelage,78,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Milling.csv
+++ b/decklists/MTG-JMP-U-Milling.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Wall of Lost Thoughts,190,Jumpstart,English
 1,Capture Sphere,47,Core Set 2021,English
 1,Teferi's Tutelage,78,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Pirates1.csv
+++ b/decklists/MTG-JMP-U-Pirates1.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Voyage's End,189,Jumpstart,English
 1,Waterknot,192,Jumpstart,English
 1,Pirate's Cutlass,477,Jumpstart,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Pirates1.csv
+++ b/decklists/MTG-JMP-U-Pirates1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Voyage's End,189,Jumpstart,English
 1,Waterknot,192,Jumpstart,English
 1,Pirate's Cutlass,477,Jumpstart,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Pirates2.csv
+++ b/decklists/MTG-JMP-U-Pirates2.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Pirate's Cutlass,477,Jumpstart,English
 1,Capture Sphere,47,Core Set 2021,English
 1,Read the Tides,62,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Pirates2.csv
+++ b/decklists/MTG-JMP-U-Pirates2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Pirate's Cutlass,477,Jumpstart,English
 1,Capture Sphere,47,Core Set 2021,English
 1,Read the Tides,62,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Spirits1.csv
+++ b/decklists/MTG-JMP-U-Spirits1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Roaming Ghostlight,65,Core Set 2021,English
 1,Shacklegeist,70,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Spirits1.csv
+++ b/decklists/MTG-JMP-U-Spirits1.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Roaming Ghostlight,65,Core Set 2021,English
 1,Shacklegeist,70,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Spirits2.csv
+++ b/decklists/MTG-JMP-U-Spirits2.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rookie Mistake,66,Core Set 2021,English
 1,Shacklegeist,70,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Spirits2.csv
+++ b/decklists/MTG-JMP-U-Spirits2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rookie Mistake,66,Core Set 2021,English
 1,Shacklegeist,70,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Teferi.csv
+++ b/decklists/MTG-JMP-U-Teferi.csv
@@ -13,7 +13,7 @@ Count,Name,Card Number,Edition,Language
 1,Teferi's Tutelage,78,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English
 1,Island,310,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Teferi.csv
+++ b/decklists/MTG-JMP-U-Teferi.csv
@@ -13,5 +13,7 @@ Count,Name,Card Number,Edition,Language
 1,Teferi's Tutelage,78,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English
 1,Island,310,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead1.csv
+++ b/decklists/MTG-JMP-U-WellRead1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rousing Read,67,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead1.csv
+++ b/decklists/MTG-JMP-U-WellRead1.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rousing Read,67,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead2.csv
+++ b/decklists/MTG-JMP-U-WellRead2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rousing Read,67,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead2.csv
+++ b/decklists/MTG-JMP-U-WellRead2.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rousing Read,67,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead3.csv
+++ b/decklists/MTG-JMP-U-WellRead3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Opt,59,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead3.csv
+++ b/decklists/MTG-JMP-U-WellRead3.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Opt,59,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead4.csv
+++ b/decklists/MTG-JMP-U-WellRead4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Opt,59,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-WellRead4.csv
+++ b/decklists/MTG-JMP-U-WellRead4.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Opt,59,Core Set 2021,English
 1,Tolarian Kraken,80,Core Set 2021,English
 1,Tome Anima,81,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Wizards1.csv
+++ b/decklists/MTG-JMP-U-Wizards1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Read the Tides,62,Core Set 2021,English
 1,Shipwreck Dowser,71,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Wizards1.csv
+++ b/decklists/MTG-JMP-U-Wizards1.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Read the Tides,62,Core Set 2021,English
 1,Shipwreck Dowser,71,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Wizards3.csv
+++ b/decklists/MTG-JMP-U-Wizards3.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Teferi's Protege,77,Core Set 2021,English
 1,Unsubstantiate,82,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Wizards3.csv
+++ b/decklists/MTG-JMP-U-Wizards3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Teferi's Protege,77,Core Set 2021,English
 1,Unsubstantiate,82,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Wizards4.csv
+++ b/decklists/MTG-JMP-U-Wizards4.csv
@@ -14,6 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Shipwreck Dowser,71,Core Set 2021,English
 1,Teferi's Protege,77,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-2,Island,265,Core Set 2021,English
 2,Island,263,Core Set 2021,English
 2,Island,264,Core Set 2021,English
+2,Island,265,Core Set 2021,English

--- a/decklists/MTG-JMP-U-Wizards4.csv
+++ b/decklists/MTG-JMP-U-Wizards4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Shipwreck Dowser,71,Core Set 2021,English
 1,Teferi's Protege,77,Core Set 2021,English
 1,Vodalian Arcanist,83,Core Set 2021,English
-6,Island,,Core Set 2021,English
+2,Island,265,Core Set 2021,English
+2,Island,263,Core Set 2021,English
+2,Island,264,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Angels1.csv
+++ b/decklists/MTG-JMP-W-Angels1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Baneslayer Angel,6,Core Set 2021,English
 1,Celestial Enforcer,11,Core Set 2021,English
 1,Feat of Resistance,19,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Angels2.csv
+++ b/decklists/MTG-JMP-W-Angels2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Angelic Ascension,3,Core Set 2021,English
 1,Anointed Chorister,4,Core Set 2021,English
 1,Celestial Enforcer,11,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Armored1.csv
+++ b/decklists/MTG-JMP-W-Armored1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Secure the Scene,35,Core Set 2021,English
 1,Siege Striker,37,Core Set 2021,English
 1,Tempered Veteran,41,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Armored2.csv
+++ b/decklists/MTG-JMP-W-Armored2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Secure the Scene,35,Core Set 2021,English
 1,Siege Striker,37,Core Set 2021,English
 1,Tempered Veteran,41,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Armored3.csv
+++ b/decklists/MTG-JMP-W-Armored3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Basri's Solidarity,10,Core Set 2021,English
 1,Makeshift Battalion,26,Core Set 2021,English
 1,Tempered Veteran,41,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Armored4.csv
+++ b/decklists/MTG-JMP-W-Armored4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Siege Striker,37,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
 1,Tempered Veteran,41,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Basri.csv
+++ b/decklists/MTG-JMP-W-Basri.csv
@@ -12,5 +12,7 @@ Count,Name,Card Number,Edition,Language
 1,Siege Striker,37,Core Set 2021,English
 1,Staunch Shieldmate,39,Core Set 2021,English
 1,Tempered Veteran,41,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English
 1,Plains,309,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Doctor1.csv
+++ b/decklists/MTG-JMP-W-Doctor1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Revitalize,31,Core Set 2021,English
 1,Speaker of the Heavens,38,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Doctor2.csv
+++ b/decklists/MTG-JMP-W-Doctor2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Secure the Scene,35,Core Set 2021,English
 1,Speaker of the Heavens,38,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Doctor3.csv
+++ b/decklists/MTG-JMP-W-Doctor3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Light of Promise,25,Core Set 2021,English
 1,Revitalize,31,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Doctor4.csv
+++ b/decklists/MTG-JMP-W-Doctor4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Griffin Aerie,22,Core Set 2021,English
 1,Revitalize,31,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Dogs1.csv
+++ b/decklists/MTG-JMP-W-Dogs1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Rambunctious Mutt,30,Core Set 2021,English
 1,Secure the Scene,35,Core Set 2021,English
 1,Selfless Savior,36,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Dogs2.csv
+++ b/decklists/MTG-JMP-W-Dogs2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Pack Leader,29,Core Set 2021,English
 1,Rambunctious Mutt,30,Core Set 2021,English
 1,Secure the Scene,35,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Enchanted1.csv
+++ b/decklists/MTG-JMP-W-Enchanted1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Anointed Chorister,4,Core Set 2021,English
 1,Dub,16,Core Set 2021,English
 1,Faith's Fetters,17,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Enchanted2.csv
+++ b/decklists/MTG-JMP-W-Enchanted2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Knightly Valor,115,Jumpstart,English
 1,Faith's Fetters,17,Core Set 2021,English
 1,Staunch Shieldmate,39,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Feathered1.csv
+++ b/decklists/MTG-JMP-W-Feathered1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Falconer Adept,18,Core Set 2021,English
 1,Gale Swooper,20,Core Set 2021,English
 1,Warded Battlements,44,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Feathered2.csv
+++ b/decklists/MTG-JMP-W-Feathered2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Gale Swooper,20,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
 1,Warded Battlements,44,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Feathered3.csv
+++ b/decklists/MTG-JMP-W-Feathered3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Gale Swooper,20,Core Set 2021,English
 1,Swift Response,40,Core Set 2021,English
 1,Warded Battlements,44,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Feathered4.csv
+++ b/decklists/MTG-JMP-W-Feathered4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Falconer Adept,18,Core Set 2021,English
 1,Gale Swooper,20,Core Set 2021,English
 1,Warded Battlements,44,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Legion1.csv
+++ b/decklists/MTG-JMP-W-Legion1.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Makeshift Battalion,26,Core Set 2021,English
 1,Selfless Savior,36,Core Set 2021,English
 1,Valorous Steed,42,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Legion2.csv
+++ b/decklists/MTG-JMP-W-Legion2.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Siege Striker,37,Core Set 2021,English
 1,Staunch Shieldmate,39,Core Set 2021,English
 1,Valorous Steed,42,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Legion3.csv
+++ b/decklists/MTG-JMP-W-Legion3.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Siege Striker,37,Core Set 2021,English
 1,Staunch Shieldmate,39,Core Set 2021,English
 1,Valorous Steed,42,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Legion4.csv
+++ b/decklists/MTG-JMP-W-Legion4.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Selfless Savior,36,Core Set 2021,English
 1,Siege Striker,37,Core Set 2021,English
 1,Valorous Steed,42,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English

--- a/decklists/MTG-JMP-W-Unicorns.csv
+++ b/decklists/MTG-JMP-W-Unicorns.csv
@@ -14,4 +14,6 @@ Count,Name,Card Number,Edition,Language
 1,Daybreak Charger,14,Core Set 2021,English
 1,Faith's Fetters,17,Core Set 2021,English
 1,Valorous Steed,42,Core Set 2021,English
-6,Plains,,Core Set 2021,English
+2,Plains,260,Core Set 2021,English
+2,Plains,261,Core Set 2021,English
+2,Plains,262,Core Set 2021,English


### PR DESCRIPTION
I can confirm only:
Jumpstart - (B) Minions 1.csv
Jumpstart - (B) Phyrexian.csv
Jumpstart - (B) Spooky 4.csv
Jumpstart - (B) Vampires 4.csv
Jumpstart - (G) Cats 2.csv
Jumpstart - (G) Dinosaurs 3.csv
Jumpstart - (G) Lands 2.csv
Jumpstart - (G) Predatory 1.csv
Jumpstart - (R) Lightning 2.csv
Jumpstart - (R) Smashing 1.csv
Jumpstart - (U) Spirits 1.csv
Jumpstart - (W) Enchanted 1.csv
Jumpstart - (W) Heavily Armored 3.csv
As I don't have other packs, but all the 6 lands i saw had 2-2-2 split.
Note: some decks have 5 or 7 basics. I left them unchanged